### PR TITLE
Fix accidentally bypassed instanceof checks

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -1557,7 +1557,7 @@ XPathJS = (function(){
 			result
 		;
 		
-		if(!nodeset instanceof NodeSetType)
+		if(!(nodeset instanceof NodeSetType))
 		{
 			throw new Error('NodeSetType can be passed into NodeSetType.append method');
 		}
@@ -2227,7 +2227,7 @@ XPathJS = (function(){
 			{
 				nodeset = evaluateExpressionTree(this, left);
 				
-				if (!nodeset instanceof NodeSetType)
+				if (!(nodeset instanceof NodeSetType))
 				{
 					throw new Error('Left side of path separator (/) must be of node-set type. (type: ' + nodeset.type + ')');
 				}
@@ -2253,7 +2253,7 @@ XPathJS = (function(){
 					newContext = this.clone(nodeset.value[i]);
 					nodeset2 = evaluateExpressionTree(newContext, right);
 				
-					if (!nodeset2 instanceof NodeSetType)
+					if (!(nodeset2 instanceof NodeSetType))
 					{
 						throw new Error('Right side of path separator (/) must be of node-set type. (type: ' + nodeset2.type + ')');
 					}
@@ -2528,7 +2528,7 @@ XPathJS = (function(){
 			nodeset = evaluateExpressionTree(this, expr);
 			
 			// Ensure we get a node-set
-			if (!nodeset instanceof NodeSetType)
+			if (!(nodeset instanceof NodeSetType))
 			{
 				throw new Error('Expected "node-set", got: ' + nodeset.type);
 			}
@@ -2730,7 +2730,7 @@ XPathJS = (function(){
 			
 			result = fnInfo.fn.apply(this, argVals);
 			
-			if (!result instanceof BaseType)
+			if (!(result instanceof BaseType))
 			{
 				throw new Error('Function "' + formatName(qname) + '" did not return a value that inherits from BaseType.');
 			}
@@ -2749,8 +2749,8 @@ XPathJS = (function(){
 			
 			if (typeof left == 'undefined' ||
 				typeof right == 'undefined' ||
-				!left instanceof NodeSetType ||
-				!right instanceof NodeSetType)
+				!(left instanceof NodeSetType) ||
+				!(right instanceof NodeSetType))
 			{
 				throw new Error('Unable to perform union on non-"node-set" types.');
 			}
@@ -3895,7 +3895,7 @@ XPathJS = (function(){
 			case XPathResult.ORDERED_NODE_SNAPSHOT_TYPE:
 			case XPathResult.ANY_UNORDERED_NODE_TYPE:
 			case XPathResult.FIRST_ORDERED_NODE_TYPE:
-				if (!value instanceof NodeSetType)
+				if (!(value instanceof NodeSetType))
 				{
 					throw new Error('Expected result of type "node-set", got: "' + value.type + '"');
 				}


### PR DESCRIPTION
This patch fixes #30 where negated instanceof checks are bypassed due to missing parentheses.